### PR TITLE
[PLATFORM-1960] Add topics to repository

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,5 @@
+repository:
+  # See https://docs.github.com/en/rest/reference/repos#update-a-repository for all available settings.
+  name: dbt-home-test
+  description: "OakNorth DBT Home Test"
+  topics: "squad::Data Platform, mission::Platform, product::Platform, environment::Pre-Production"

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,5 +1,5 @@
 repository:
   # See https://docs.github.com/en/rest/reference/repos#update-a-repository for all available settings.
   name: dbt-home-test
-  description: "OakNorth DBT Home Test"
-  topics: "squad::Data Platform, mission::Platform, product::Platform, environment::Pre-Production"
+  description: OakNorth DBT Home Test
+  topics: squad-data-platform, mission-platform, product-platform, environment-pre-production


### PR DESCRIPTION
In order to easily group GitHub repositories together, we utilise topics to act as labels. We assign a squad to each repository to act as the main point of contact. Read more here: https://oaknorth-bank.atlassian.net/wiki/spaces/ENG/pages/287670416/GitHub+Topics